### PR TITLE
 Fix clone failure in Linux environment (temp dir problem) - JP: Linux環境でのclone失敗の修正

### DIFF
--- a/main.rs
+++ b/main.rs
@@ -152,7 +152,7 @@ fn get_event (ev: &Event) -> String {
 
 fn main() {
     // get args
-    let mut args: Vec<String> = env::args().collect();
+    let args: Vec<String> = env::args().collect();
 
     const VERSION: &str = env!("CARGO_PKG_VERSION");
 
@@ -168,50 +168,6 @@ fn main() {
         println!("git-lfs-agent-rclone v{}", VERSION);
         // exit
         std::process::exit(0);
-    }
-
-    // set environment variable
-    if let Some(index) = args.iter().position(|elem| elem == "--tmpdir") {
-        args.remove(index);
-        if args.len() <= index {
-            respond(Response::Error(ErrorResponse {
-                event: "initialize".to_string(),
-                oid: "-1".to_string(),
-                error: Error {
-                    code: 1,
-                    message: "`--tmpdir` needs a temporary directory path".to_string(),
-                },
-            }));
-            std::process::exit(1);
-        }
-        match std::fs::metadata(&args[index]) {
-            Ok(path) => {
-                if !path.is_dir() {
-                    respond(Response::Error(ErrorResponse {
-                        event: "initialize".to_string(),
-                        oid: "-1".to_string(),
-                        error: Error {
-                            code: 1,
-                            message: "given temporary directory path is invalid.".to_string(),
-                        },
-                    }));
-                    std::process::exit(1);
-                }
-            }
-            Err(mes) => {
-                respond(Response::Error(ErrorResponse {
-                    event: "initialize".to_string(),
-                    oid: "-1".to_string(),
-                    error: Error {
-                        code: 1,
-                        message: mes.to_string(),
-                    },
-                }));
-                std::process::exit(1);
-            }
-        }
-        std::env::set_var("TMPDIR", &args[index]);
-        args.remove(index);
     }
 
     let rclone_args = &args[1..];

--- a/main.rs
+++ b/main.rs
@@ -152,7 +152,7 @@ fn get_event (ev: &Event) -> String {
 
 fn main() {
     // get args
-    let args: Vec<String> = env::args().collect();
+    let mut args: Vec<String> = env::args().collect();
 
     const VERSION: &str = env!("CARGO_PKG_VERSION");
 
@@ -168,6 +168,50 @@ fn main() {
         println!("git-lfs-agent-rclone v{}", VERSION);
         // exit
         std::process::exit(0);
+    }
+
+    // set environment variable
+    if let Some(index) = args.iter().position(|elem| elem == "--tmpdir") {
+        args.remove(index);
+        if args.len() <= index {
+            respond(Response::Error(ErrorResponse {
+                event: "initialize".to_string(),
+                oid: "-1".to_string(),
+                error: Error {
+                    code: 1,
+                    message: "`--tmpdir` needs a temporary directory path".to_string(),
+                },
+            }));
+            std::process::exit(1);
+        }
+        match std::fs::metadata(&args[index]) {
+            Ok(path) => {
+                if !path.is_dir() {
+                    respond(Response::Error(ErrorResponse {
+                        event: "initialize".to_string(),
+                        oid: "-1".to_string(),
+                        error: Error {
+                            code: 1,
+                            message: "given temporary directory path is invalid.".to_string(),
+                        },
+                    }));
+                    std::process::exit(1);
+                }
+            }
+            Err(mes) => {
+                respond(Response::Error(ErrorResponse {
+                    event: "initialize".to_string(),
+                    oid: "-1".to_string(),
+                    error: Error {
+                        code: 1,
+                        message: mes.to_string(),
+                    },
+                }));
+                std::process::exit(1);
+            }
+        }
+        std::env::set_var("TMPDIR", &args[index]);
+        args.remove(index);
     }
 
     let rclone_args = &args[1..];
@@ -229,8 +273,8 @@ fn main() {
                 _ => panic!("invalid event"),
             };
             // call rclone to download file
-            let (_tmp_file, tmp_path_buf) = tempfile::NamedTempFile::new().unwrap().keep().unwrap();
-            let tmp_path = tmp_path_buf.to_str().unwrap();
+            let _tmp_dir = tempfile::tempdir().unwrap();
+            let tmp_path = _tmp_dir.into_path();
 
             let sep = "/";
             // let src_path = Path::new(&rclone_arg_str).join(&ev.oid);
@@ -238,14 +282,14 @@ fn main() {
             let cmd = Command::new("rclone")
                 .arg("copy")
                 .arg(src_path)
-                .arg(tmp_path)
+                .arg(tmp_path.to_str().unwrap().to_string())
                 .output()
                 .expect("failed to execute process");
             if cmd.status.success() {
                 respond(Response::Download(DownloadResponse {
                     event: "complete".to_string(),
                     oid: ev.oid.clone(),
-                    path: tmp_path.to_string(),
+                    path: tmp_path.join(&ev.oid).to_str().unwrap().to_string(),
                 }));
             } else {
                 respond(Response::Error(ErrorResponse {


### PR DESCRIPTION
プルリクに不慣れのため不適切な箇所があれば，ご指摘いただけますと幸いです．よろしくお願いいたします．

## 症状

git-lfsで管理しているリポジトリを `git clone <repo>` で取ってこようとしたところ，エラーが生じました．READMEのUsageに記載いただいている項目は設定済みでした．

`~/.git-lfs-agent-rclone/logs/errors.log` に出力されたエラーは下記のとおりです．`oid: 6f5cd1413e663155016e92bd9e991652f282970d724b792b7af34c9a918xxxxx` はgit-lfsで管理しているファイルのハッシュ値です．
```
download failed: Output { status: ExitStatus(unix_wait_status(256)), stdout: "", stderr: "2023/11/30 18:39:03 Failed to create file system for \"/tmp/.tmpv6QGNz\": is a file not a directory\n" } ( request json: EventDownload { event: "download", oid: "6f5cd1413e663155016e92bd9e991652f282970d724b792b7af34c9a918xxxxx", size: 148000768, action: None })
download failed: Output { status: ExitStatus(unix_wait_status(256)), stdout: "", stderr: "2023/11/30 18:39:03 Failed to create file system for \"/tmp/.tmpWSRJKy\": is a file not a directory\n" } ( request json: EventDownload { event: "download", oid: "6f5cd1413e663155016e92bd9e991652f282970d724b792b7af34c9a918xxxxx", size: 148000768, action: None })
```


## 実行環境

```
❯ cat /proc/version                           
Linux version 6.6.3-arch1-1 (linux@archlinux) (gcc (GCC) 13.2.1 20230801, GNU ld (GNU Binutils) 2.41.0) #1 SMP PREEMPT_DYNAMIC Wed, 29 Nov 2023 00:37:40 +0000

❯ cat /etc/os-release   
NAME="Arch Linux"
PRETTY_NAME="Arch Linux"
ID=arch
BUILD_ID=rolling
ANSI_COLOR="38;2;23;147;209"
HOME_URL="https://archlinux.org/"
DOCUMENTATION_URL="https://wiki.archlinux.org/"
SUPPORT_URL="https://bbs.archlinux.org/"
BUG_REPORT_URL="https://bugs.archlinux.org/"
PRIVACY_POLICY_URL="https://terms.archlinux.org/docs/privacy-policy/"
LOGO=archlinux-logo

❯ rustc --version
rustc 1.73.0 (cc66ad468 2023-10-03)

❯ cargo --version       
cargo 1.73.0 (9c4383fb5 2023-08-26)

❯ git-lfs --version                           
git-lfs/3.4.0 (GitHub; linux amd64; go 1.21.3)

❯ git --version                               
git version 2.43.0
```

## 考えうる原因

[`download` 処理時](https://github.com/funatsufumiya/git-lfs-agent-rclone/blob/cbaafe8163b81e50feb31d34e0395fb5d701884e/main.rs#L232)，ローカルに一時ファイル(`tmp_path`)を作成し，そこへLFSでの管理ファイルをダウンロードするようになっていますが，`rclone` で期待されているのはディレクトリのため前述のようなエラーが生じているのではと考えました．

## 修正方針

基本方針は **一時ファイルを作成するのではなく，一時フォルダを作成しそこに `rclone` する** というものです．そこから派生する問題として以下がありました．

* `git-lfs` では内部で `os.Rename` が使われており，一部のLinux環境では `/tmp` 配下にダウンロードしてくると，`os.Rename` が正常に実行できない[問題](https://qiita.com/pankona/items/8098fd94fa4d3fbe387b)がある．

これは一部のLinux環境では，`tmpfs` に `/tmp` がマウントされていることから，ホームディレクトリ等とパーティションが異なることに起因します．これを解決するために `--tmpdir` という引数で明示的に一時フォルダの作成場所を指定できるようにしました．

## 懸念点

git関連のツールを開発したことがないため，動作確認に適切なテストの仕方がわかりませんでした．可能であれば参考になるリポジトリなどをお教えいただければ，追加で修正する所存です．